### PR TITLE
Fix cleanup, IAM, and stop-condition issues in sqs-queue-impairment

### DIFF
--- a/sqs-queue-impairment/README.md
+++ b/sqs-queue-impairment/README.md
@@ -38,7 +38,9 @@ This experiment simulates a worsening impairment of an SQS queue by applying a d
 6. Wait period: 2 minutes of normal operation
 7. Fourth impairment: Blocks access to the SQS queue for 15 minutes
 
-The impairment is implemented using an SSM Automation Document invoked by FIS. The SSM Automation Document adds a deny statement to the SQS queue policy that prevents all principals from performing key operations like sending and receiving messages. After the specified duration, the Automation Document removes the deny statement, restoring normal access to the queue.
+The impairment is implemented using an SSM Automation Document invoked by FIS. The SSM Automation Document adds a deny statement to the SQS queue policy that blocks data-plane operations like sending and receiving messages. After the specified duration, the Automation Document removes the deny statement, restoring normal access to the queue.
+
+By default the deny applies to all principals (`Principal: "*"`), simulating a full service partition. To impair only your application — and leave admins, monitoring, and other consumers of the queue unaffected — set the optional `targetPrincipalArn` parameter to the application's IAM role ARN; the deny is then scoped to that principal. The deny covers only data-plane actions (`SendMessage`, `ReceiveMessage`, `DeleteMessage`, `ChangeMessageVisibility`, `PurgeQueue`) and never queue-management actions, so the automation (and your admins) can always remove it.
 
 To verify the experiment is setup and working properly, you can use the AWS CLI to attempt operations on a targeted SQS queue:
 
@@ -50,13 +52,42 @@ During the impairment periods, you should see "AccessDenied" errors when attempt
 
 ![FIS Console showing actions](./images/sqs.png "FIS Console showing actions")
 
-## Stop Conditions
-
-The experiment does not have any specific stop conditions defined. It will continue to run until all actions are completed or until manually stopped.
-
 ## Observability and stop conditions
 
-Stop conditions are based on an AWS CloudWatch alarm based on an operational or business metric requiring an immediate end of the fault injection. This template makes no assumptions about your application and the relevant metrics and does not include stop conditions by default.
+Stop conditions are based on an AWS CloudWatch alarm tied to an operational or business metric requiring an immediate end of the fault injection. This template makes no assumptions about your application and the relevant metrics, so it does not include stop conditions by default (`"stopConditions": [{ "source": "none" }]`).
+
+**Choose the stop-condition metric carefully.** Do *not* alarm on the queue metrics this experiment perturbs (`ApproximateAgeOfOldestMessage`, `NumberOfMessagesSent`, `ApproximateNumberOfMessagesVisible` on the source queue). Those are expected to move during impairment, so an alarm on them would abort the experiment during the first short phase — before the longer phases surface the failure modes you care about. Instead, alarm on a signal that should stay healthy if your resilience works, i.e. real customer/business impact:
+
+* An application error-rate or transaction-success metric your app emits (best — directly measures customer impact).
+* Load balancer 5xx count or target response time (a good proxy if you don't yet emit a business metric).
+* Dead-letter queue depth (`ApproximateNumberOfMessagesVisible` on the **DLQ**), which signals permanent message failure rather than recoverable backlog.
+
+Create the alarm, then reference it in the experiment template's `stopConditions`:
+
+```json
+"stopConditions": [
+  {
+    "source": "aws:cloudwatch:alarm",
+    "value": "arn:aws:cloudwatch:<YOUR REGION>:<YOUR AWS ACCOUNT>:alarm:sqs-fis-customer-impact"
+  }
+]
+```
+
+Example alarm using ALB 5xx errors as a customer-impact proxy. Set the threshold above normal noise but below a real outage, use a short evaluation window so the experiment aborts quickly, and treat missing data as not breaching so idle periods don't trip it:
+
+```bash
+aws cloudwatch put-metric-alarm \
+  --alarm-name sqs-fis-customer-impact \
+  --namespace AWS/ApplicationELB \
+  --metric-name HTTPCode_Target_5XX_Count \
+  --dimensions Name=LoadBalancer,Value=app/<YOUR APP>/<ID> \
+  --statistic Sum --period 60 --evaluation-periods 1 \
+  --threshold 50 --comparison-operator GreaterThanThreshold \
+  --treat-missing-data notBreaching \
+  --region <YOUR REGION>
+```
+
+See [Stop conditions for AWS FIS](https://docs.aws.amazon.com/fis/latest/userguide/stop-conditions.html).
 
 ## Next Steps
 
@@ -64,9 +95,8 @@ As you adapt this scenario to your needs, we recommend:
 
 1. Reviewing the tag names you use to ensure they fit your specific use case.
 2. Identifying business metrics tied to your SQS queue processing, such as application transaction rates.
-3. Creating an Amazon CloudWatch metric and Amazon CloudWatch alarm to monitor the impact of the SQS impairment.
-4. Adding a stop condition tied to the alarm to automatically halt the experiment if critical thresholds are breached.
-5. Implementing appropriate circuit breakers in your application to handle SQS service impairments gracefully.
+3. **Before running anything beyond a short test, add a stop condition** tied to a customer-impact alarm so the experiment aborts automatically if critical thresholds are breached (see [Observability and stop conditions](#observability-and-stop-conditions) for how to choose the metric and an example alarm).
+4. Implementing appropriate circuit breakers in your application to handle SQS service impairments gracefully.
 6. Testing your application's recovery mechanisms to ensure they work as expected after the SQS service is restored.
 7. Documenting the findings from your experiment and updating your incident response procedures accordingly.
 

--- a/sqs-queue-impairment/fis-iam-trust-relationship.json
+++ b/sqs-queue-impairment/fis-iam-trust-relationship.json
@@ -6,7 +6,15 @@
             "Principal": {
                 "Service": "fis.amazonaws.com"
             },
-            "Action": "sts:AssumeRole"
+            "Action": "sts:AssumeRole",
+            "Condition": {
+                "StringEquals": {
+                    "aws:SourceAccount": "<YOUR AWS ACCOUNT>"
+                },
+                "ArnLike": {
+                    "aws:SourceArn": "arn:aws:fis:<YOUR REGION>:<YOUR AWS ACCOUNT>:experiment/*"
+                }
+            }
         }
     ]
 }

--- a/sqs-queue-impairment/sqs-queue-impairment-tag-based-automation.yaml
+++ b/sqs-queue-impairment/sqs-queue-impairment-tag-based-automation.yaml
@@ -1,4 +1,4 @@
-description: "Apply a deny-all policy to SQS queues with specific tag to simulate impairment using SQS:AddPermission and SQS:RemovePermission"
+description: "Apply a scoped deny policy to SQS queues with a specific tag to simulate impairment. The deny statement is added and removed via SQS:SetQueueAttributes so that apply and cleanup use the same (inverse) API."
 schemaVersion: "0.3"
 assumeRole: "{{ AutomationAssumeRole }}"
 parameters:
@@ -18,6 +18,10 @@ parameters:
     type: String
     description: "AWS Region of the SQS queues"
     default: "{{global:REGION}}"
+  targetPrincipalArn:
+    type: String
+    description: "Optional IAM principal (e.g. the application's role ARN) to scope the deny to. If set, only this principal loses data-plane access and other callers (admins, monitoring) are unaffected. Leave empty to deny all principals (Principal: '*'), simulating a full service partition."
+    default: ""
   AutomationAssumeRole:
     type: String
     description: "IAM role for the automation execution"
@@ -81,18 +85,27 @@ mainSteps:
         def apply_deny_policy(events, context):
             region = events['region']
             target_queues = events['targetQueues']
-            
+            target_principal = (events.get('targetPrincipalArn') or '').strip()
+
             sqs = boto3.client('sqs', region_name=region)
             results = []
-            
+
+            # Scope the deny to a single principal if one was provided, otherwise deny
+            # all principals. Scoping to the application's role means only that app loses
+            # data-plane access -- admins and monitoring are unaffected. Denying "*"
+            # simulates a full service partition where every caller loses access.
+            deny_principal = {"AWS": target_principal} if target_principal else "*"
+
             for queue_url in target_queues:
                 try:
-                    # Get existing policy
+                    # Get existing policy and the queue ARN so the deny can be scoped to this queue
                     response = sqs.get_queue_attributes(
                         QueueUrl=queue_url,
-                        AttributeNames=['Policy']
+                        AttributeNames=['Policy', 'QueueArn']
                     )
-                    
+
+                    queue_arn = response.get('Attributes', {}).get('QueueArn', '*')
+
                     existing_policy = {}
                     if 'Policy' in response.get('Attributes', {}):
                         existing_policy = json.loads(response['Attributes']['Policy'])
@@ -101,11 +114,13 @@ mainSteps:
                             "Version": "2012-10-17",
                             "Statement": []
                         }
-                    
-                    # Add deny statement
+
+                    # Add a scoped deny statement. Deny only data-plane actions so that
+                    # management actions (SetQueueAttributes, AddPermission, RemovePermission)
+                    # are never blocked and the cleanup step can always remove this statement.
                     deny_statement = {
                         "Effect": "Deny",
-                        "Principal": "*",
+                        "Principal": deny_principal,
                         "Action":  [
                           "sqs:DeleteMessage",
                           "sqs:ChangeMessageVisibility",
@@ -113,7 +128,7 @@ mainSteps:
                           "sqs:ReceiveMessage",
                           "sqs:SendMessage"
                         ],
-                        "Resource": "*",
+                        "Resource": queue_arn,
                         "Sid": "FISTemporaryDeny"
                     }
                     
@@ -140,6 +155,7 @@ mainSteps:
       InputPayload:
         region: "{{ region }}"
         targetQueues: "{{ getTargetQueues.targetQueues }}"
+        targetPrincipalArn: "{{ targetPrincipalArn }}"
     outputs:
       - Name: affectedQueues
         Selector: $.Payload.affectedQueues
@@ -164,24 +180,63 @@ mainSteps:
       Handler: remove_deny_policy
       Script: |
         import boto3
+        import json
 
         def remove_deny_policy(events, context):
             region = events['region']
             affected_queues = events['affectedQueues']
-            
+
             sqs = boto3.client('sqs', region_name=region)
             results = []
-            
+            failures = []
+
             for queue_url in affected_queues:
                 try:
-                    sqs.remove_permission(
+                    # Remove the deny statement the same way it was applied: by setting
+                    # the queue policy. RemovePermission only revokes statements added via
+                    # AddPermission (matched by Label) and will not reliably remove a
+                    # statement injected with SetQueueAttributes.
+                    response = sqs.get_queue_attributes(
                         QueueUrl=queue_url,
-                        Label='FISTemporaryDeny'
+                        AttributeNames=['Policy']
                     )
+
+                    if 'Policy' not in response.get('Attributes', {}):
+                        results.append(f"No policy found on {queue_url}; nothing to remove")
+                        continue
+
+                    policy = json.loads(response['Attributes']['Policy'])
+                    policy['Statement'] = [s for s in policy.get('Statement', [])
+                                           if s.get('Sid') != 'FISTemporaryDeny']
+
+                    if policy['Statement']:
+                        sqs.set_queue_attributes(
+                            QueueUrl=queue_url,
+                            Attributes={'Policy': json.dumps(policy)}
+                        )
+                    else:
+                        # Our deny was the only statement. SQS rejects a policy with an
+                        # empty Statement list, so the correct way to remove the policy is
+                        # to set the Policy attribute to an empty string ''. Do NOT change
+                        # this to '{}' or a {"Statement": []} document -- both are invalid
+                        # and will raise MalformedPolicy.
+                        sqs.set_queue_attributes(
+                            QueueUrl=queue_url,
+                            Attributes={'Policy': ''}
+                        )
+
                     results.append(f"Successfully removed deny policy from {queue_url}")
                 except Exception as e:
-                    results.append(f"Failed to remove deny policy from {queue_url}: {str(e)}")
-            
+                    # Collect the error but do NOT swallow it: a failed cleanup leaves the
+                    # queue impaired, so the step must surface as failed to FIS.
+                    failures.append(f"Failed to remove deny policy from {queue_url}: {str(e)}")
+
+            if failures:
+                raise RuntimeError(
+                    "Cleanup failed for one or more queues; deny policy may still be in place: "
+                    + "; ".join(failures)
+                )
+
             return results
       InputPayload:
         region: "{{ region }}"

--- a/sqs-queue-impairment/sqs-queue-impairment-tag-based-fis-role-iam-policy.json
+++ b/sqs-queue-impairment/sqs-queue-impairment-tag-based-fis-role-iam-policy.json
@@ -22,7 +22,7 @@
       ],
       "Resource": [
         "arn:aws:ssm:<YOUR REGION>:<YOUR AWS ACCOUNT>:document/<AUTOMATION DOCUMENT NAME>",
-        "arn:aws:ssm:<YOUR REGION>:<YOUR AWS ACCOUNT>:automation-definition/S<AUTOMATION DOCUMENT NAME>:*",
+        "arn:aws:ssm:<YOUR REGION>:<YOUR AWS ACCOUNT>:automation-definition/<AUTOMATION DOCUMENT NAME>:*",
         "arn:aws:ssm:<YOUR REGION>:<YOUR AWS ACCOUNT>:automation-execution/*"
       ]
     },

--- a/sqs-queue-impairment/sqs-queue-impairment-tag-based-ssm-automation-role-iam-policy.json
+++ b/sqs-queue-impairment/sqs-queue-impairment-tag-based-ssm-automation-role-iam-policy.json
@@ -2,12 +2,18 @@
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "AllowQueueDiscovery",
       "Effect": "Allow",
       "Action": [
         "sqs:ListQueues",
-        "sqs:ListQueueTags",
-        "sqs:AddPermission",
-        "sqs:RemovePermission",
+        "sqs:ListQueueTags"
+      ],
+      "Resource": "arn:aws:sqs:<YOUR REGION>:<YOUR AWS ACCOUNT>:*"
+    },
+    {
+      "Sid": "AllowPolicyChangeOnTaggedQueues",
+      "Effect": "Allow",
+      "Action": [
         "sqs:GetQueueAttributes",
         "sqs:SetQueueAttributes"
       ],


### PR DESCRIPTION
Automation document (sqs-queue-impairment-tag-based-automation.yaml):
- Fix cleanup to remove the FISTemporaryDeny statement via SetQueueAttributes (the inverse of how it is applied) instead of RemovePermission, which only revokes AddPermission/label-based statements and would not reliably remove a statement injected with SetQueueAttributes.
- Re-raise on cleanup failure instead of swallowing the exception, so a failed restore surfaces to FIS instead of leaving a queue impaired silently.
- Document the empty-Policy removal idiom (set Policy to '') so it is not "fixed" to an invalid '{}' / empty-Statement document.
- Scope the deny Resource to the queue ARN instead of "*".
- Add optional targetPrincipalArn parameter: scope the deny to a single principal (e.g. the application's role) so admins and monitoring keep access; defaults to "*" (full-partition simulation).

IAM:
- SSM automation role: split ListQueues/ListQueueTags into their own statement without the aws:ResourceTag/FIS-Ready condition (account-level resource has no tags, so the condition could never be satisfied and ListQueues was implicitly denied, breaking the getTargetQueues step). Drop unused AddPermission/ RemovePermission now that apply and cleanup both use SetQueueAttributes.
- FIS role: add aws:SourceAccount/aws:SourceArn confused-deputy conditions to the trust relationship; fix stray "S" typo in the automation-definition ARN.

README:
- Remove stale "Stop Conditions" section that contradicted the new guidance.
- Add stop-condition guidance: do not alarm on the perturbed queue metrics; alarm on a customer-impact signal, with an example ALB 5xx alarm + the stopConditions block. Document the targetPrincipalArn scoping behavior.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
